### PR TITLE
Rename PlaylistNavigator to TrackNavigationControls

### DIFF
--- a/app/src/main/java/com/virtualrealm/virtualrealmmusicplayer/ui/player/AlbumArtSection.kt
+++ b/app/src/main/java/com/virtualrealm/virtualrealmmusicplayer/ui/player/AlbumArtSection.kt
@@ -2,8 +2,6 @@ package com.virtualrealm.virtualrealmmusicplayer.ui.player
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.layout.ColumnScopeInstance.align
-import androidx.compose.foundation.layout.FlowColumnScopeInstance.align
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MusicNote
@@ -123,7 +121,7 @@ fun SourceOverlayIcon(
     Box(
         modifier = Modifier
             .size(80.dp)
-            .align(Alignment.Center)
+            // Remove the problematic align modifier
             .background(
                 color = Color.Black.copy(alpha = 0.6f),
                 shape = RoundedCornerShape(8.dp)

--- a/app/src/main/java/com/virtualrealm/virtualrealmmusicplayer/ui/player/MusicInfoSection.kt
+++ b/app/src/main/java/com/virtualrealm/virtualrealmmusicplayer/ui/player/MusicInfoSection.kt
@@ -1,9 +1,6 @@
 package com.virtualrealm.virtualrealmmusicplayer.ui.player
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
@@ -11,8 +8,6 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -87,8 +82,7 @@ fun MusicInfoSection(
 
                 SourceTag(
                     text = "Spotify",
-                    contentColor = SpotifyGreen,
-                    modifier = Modifier.align(Alignment.CenterHorizontally)
+                    contentColor = SpotifyGreen
                 )
             }
             is Music.YoutubeVideo -> {
@@ -106,8 +100,7 @@ fun MusicInfoSection(
 
                 SourceTag(
                     text = "YouTube",
-                    contentColor = YouTubeRed,
-                    modifier = Modifier.align(Alignment.CenterHorizontally)
+                    contentColor = YouTubeRed
                 )
             }
         }
@@ -132,9 +125,9 @@ fun MusicInfoSection(
             onSkipNext = onSkipNext
         )
 
-        // Playlist navigator
+        // Playlist navigator - using the renamed TrackNavigationControls
         if (playlist.isNotEmpty() && playlist.size > 1) {
-            PlaylistNavigator(
+            TrackNavigationControls(
                 playlist = playlist,
                 currentIndex = currentIndex,
                 onPreviousClick = onSkipPrevious,
@@ -149,9 +142,7 @@ fun MusicInfoSection(
         // Favorite button
         IconButton(
             onClick = onToggleFavorite,
-            modifier = Modifier
-                .size(48.dp)
-                .align(Alignment.CenterHorizontally)
+            modifier = Modifier.size(48.dp)
         ) {
             Icon(
                 imageVector = if (isFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,

--- a/app/src/main/java/com/virtualrealm/virtualrealmmusicplayer/ui/player/PlaylistNavigator.kt
+++ b/app/src/main/java/com/virtualrealm/virtualrealmmusicplayer/ui/player/PlaylistNavigator.kt
@@ -17,8 +17,14 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.virtualrealm.virtualrealmmusicplayer.domain.model.Music
 
+/**
+ * A composable that displays navigation controls for a playlist
+ *
+ * NOTE: Function name changed from PlaylistNavigator to TrackNavigationControls
+ * to avoid conflicts with another function with the same name in the codebase
+ */
 @Composable
-fun PlaylistNavigator(
+fun TrackNavigationControls(
     playlist: List<Music>,
     currentIndex: Int,
     onPreviousClick: () -> Unit,
@@ -106,82 +112,124 @@ fun PlaylistNavigator(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 // Previous track preview
-                prevTrack?.let { track ->
-                    TrackPreview(
-                        track = track,
-                        isNext = false,
-                        onClick = onPreviousClick
+                if (prevTrack != null) {
+                    PrevTrackPreview(
+                        track = prevTrack,
+                        onClick = onPreviousClick,
+                        modifier = Modifier.weight(1f)
                     )
-                } ?: Spacer(modifier = Modifier.weight(1f))
+                } else {
+                    Spacer(modifier = Modifier.weight(1f))
+                }
 
                 // Spacer in the middle
                 Spacer(modifier = Modifier.width(8.dp))
 
                 // Next track preview
-                nextTrack?.let { track ->
-                    TrackPreview(
-                        track = track,
-                        isNext = true,
-                        onClick = onNextClick
+                if (nextTrack != null) {
+                    NextTrackPreview(
+                        track = nextTrack,
+                        onClick = onNextClick,
+                        modifier = Modifier.weight(1f)
                     )
-                } ?: Spacer(modifier = Modifier.weight(1f))
+                } else {
+                    Spacer(modifier = Modifier.weight(1f))
+                }
             }
         }
     }
 }
 
+/**
+ * Preview for the previous track
+ */
 @Composable
-fun TrackPreview(
+private fun PrevTrackPreview(
     track: Music,
-    isNext: Boolean,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Row(
-        modifier = Modifier
-            .weight(1f)
+        modifier = modifier
             .clip(MaterialTheme.shapes.small)
             .clickable(onClick = onClick)
             .padding(8.dp),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = if (isNext) Arrangement.End else Arrangement.Start
+        horizontalArrangement = Arrangement.Start
     ) {
-        if (!isNext) {
-            Icon(
-                imageVector = Icons.Default.KeyboardArrowLeft,
-                contentDescription = "Previous",
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(16.dp)
-            )
-        }
+        Icon(
+            imageVector = Icons.Default.KeyboardArrowLeft,
+            contentDescription = "Previous",
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(16.dp)
+        )
 
         Column(
             modifier = Modifier
                 .padding(horizontal = 4.dp)
                 .weight(1f),
-            horizontalAlignment = if (isNext) Alignment.End else Alignment.Start
+            horizontalAlignment = Alignment.Start
         ) {
             Text(
-                text = if (isNext) "Next" else "Previous",
+                text = "Previous",
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.primary,
-                textAlign = if (isNext) TextAlign.End else TextAlign.Start
+                textAlign = TextAlign.Start
             )
             Text(
                 text = track.title,
                 style = MaterialTheme.typography.bodySmall,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
-                textAlign = if (isNext) TextAlign.End else TextAlign.Start
+                textAlign = TextAlign.Start
+            )
+        }
+    }
+}
+
+/**
+ * Preview for the next track
+ */
+@Composable
+private fun NextTrackPreview(
+    track: Music,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .clip(MaterialTheme.shapes.small)
+            .clickable(onClick = onClick)
+            .padding(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.End
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(horizontal = 4.dp)
+                .weight(1f),
+            horizontalAlignment = Alignment.End
+        ) {
+            Text(
+                text = "Next",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary,
+                textAlign = TextAlign.End
+            )
+            Text(
+                text = track.title,
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.End
             )
         }
 
-        if (isNext) {
-            Icon(
-                imageVector = Icons.Default.KeyboardArrowRight,
-                contentDescription = "Next",
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(16.dp)
-            )
-        }
+        Icon(
+            imageVector = Icons.Default.KeyboardArrowRight,
+            contentDescription = "Next",
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(16.dp)
+        )
     }
 }


### PR DESCRIPTION
This commit renames the `PlaylistNavigator` composable function to `TrackNavigationControls` to avoid naming conflicts with another function in the codebase.

It also refactors the track preview logic within this composable into private functions `PrevTrackPreview` and `NextTrackPreview` for better readability and separation of concerns.

Additionally, it removes a problematic `align` modifier in the `AlbumArtSection` composable that was causing layout issues.

Finally, it updates the `MusicInfoSection` to use the newly renamed `TrackNavigationControls` composable.