### PR TITLE
Fix: Resolve null safety issue in PlayerScreen FAB visibility

### DIFF
--- a/app/src/main/java/com/virtualrealm/virtualrealmmusicplayer/ui/player/PlayerScreen.kt
+++ b/app/src/main/java/com/virtualrealm/virtualrealmmusicplayer/ui/player/PlayerScreen.kt
@@ -107,6 +107,7 @@ fun PlayerScreen(
         }
     }
 
+
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
@@ -117,7 +118,9 @@ fun PlayerScreen(
             )
         },
         floatingActionButton = {
-            if (playlist.size > 1 || !music?.let { musicViewModel.isTrackInPlaylist(it) }!!) {
+            // Fix the null-safety issue by using a proper null check
+            val currentMusic = music
+            if (playlist.size > 1 || (currentMusic != null && !musicViewModel.isTrackInPlaylist(currentMusic))) {
                 PlayerFloatingButton(
                     playlistSize = playlist.size,
                     isExpanded = isPlaylistButtonExpanded,


### PR DESCRIPTION
The null safety check for `music` was not being handled correctly when determining the visibility of the Floating Action Button (FAB). This commit refactors the check to properly handle the possibility of `music` being null, ensuring the FAB is only shown when the current track is not in the playlist and the playlist has more than one item, or if `music` is null.